### PR TITLE
Simple mothership

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -93,7 +93,7 @@ pub struct FighterDrone {
 
 }
 
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct Mothership {
     pub num_entities: u32
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -9,6 +9,7 @@ impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
         app
             .add_event::<TorpedoCollisionEvent>()
+            .add_system(move_mothership)
             .add_startup_system(hello_world)
             .add_startup_system(spawn_mothership)
             .add_startup_system(setup_world);

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -10,7 +10,7 @@ impl Plugin for GamePlugin {
         app
             .add_event::<TorpedoCollisionEvent>()
             .add_startup_system(hello_world)
-            .add_startup_system(spawn_text)
+            .add_startup_system(spawn_mothership)
             .add_startup_system(setup_world);
     }
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -20,6 +20,44 @@ pub fn setup_world(mut commands: Commands) {
     });
 }
 
+pub fn spawn_mothership(mut commands: Commands, asset_server: Res<AssetServer>) {
+
+    let font = asset_server.load("fonts/FallingSkyBlack.otf");
+    let text_style = TextStyle {
+        font: font.clone(),
+        font_size: 60.0,
+        color: Color::WHITE,
+    };
+
+    let bottom_left = Vec3::new(-(MOTHERSHIP_STRUCTURE_SPACING * 5.5), -(MOTHERSHIP_STRUCTURE_SPACING * 2.5), 0.);
+    let mothership_pos = Vec3::new(0., 0., 0.);
+
+    let width = 11;
+    let height = 5;
+
+    let chars = vec!["}", "{", "6", "=", "-", "/", ":", "]", "[", "!", "#", "%", "$"];
+
+    commands.spawn((SpriteBundle{ transform: Transform::from_translation(mothership_pos), ..default() }, Mothership::default()))
+        .with_children(|parent| {
+            for x in 0..width {
+                for y in 0..height {
+                    parent.spawn((
+                        Text2dBundle{ 
+                            text: Text { 
+                                sections: vec![TextSection::new(chars[(x + y) % 13], text_style.clone())],
+                                ..default()
+                            },
+                            transform: Transform::from_translation(bottom_left + Vec3::new(x as f32 * MOTHERSHIP_STRUCTURE_SPACING, y as f32 * MOTHERSHIP_STRUCTURE_SPACING, 0.)),
+                            ..default()
+                        }, 
+                        Structure{ integrity: 5, max_integrity: 5 }
+                    ));
+                }
+            }
+        }
+    );
+}
+
 pub fn spawn_text(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     let font = asset_server.load("fonts/FallingSkyBlack.otf");

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -111,7 +111,7 @@ pub fn move_projectile(time: Res<Time>, mut query: Query<(&mut Transform, &Veloc
     }
 }
 
-pub fn move_mothership(time: Res<Time>, mut query: Query<&mut Transform>) {
+pub fn move_mothership(time: Res<Time>, mut query: Query<&mut Transform, With<Mothership>>) {
     let dt = time.delta_seconds();
 
     for mut transform in &mut query {

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -58,44 +58,6 @@ pub fn spawn_mothership(mut commands: Commands, asset_server: Res<AssetServer>) 
     );
 }
 
-pub fn spawn_text(mut commands: Commands, asset_server: Res<AssetServer>) {
-
-    let font = asset_server.load("fonts/FallingSkyBlack.otf");
-    let text_style = TextStyle {
-        font: font.clone(),
-        font_size: 60.0,
-        color: Color::WHITE,
-    };
-
-    let count = 10;
-    let start_pos = Vec3::new(-150., -50., 0.);
-    let end_pos = start_pos + Vec3::new(MOTHERSHIP_STRUCTURE_SPACING, 0., 0.) * count as f32;
-
-    let chars = vec!["}", "{", "6", "=", "-", "/", ":", "]", "[", "!", "#", "%", "$"];
-    for i in 0..count {
-        let pos = start_pos.lerp(end_pos, i as f32 / count as f32);
-
-        commands.spawn(Text2dBundle{
-            text: Text {
-                sections: vec![TextSection::new(chars[i], text_style.clone())],
-                ..default()
-            },
-            transform: Transform::from_translation(pos),
-            ..default()
-        });
-
-        commands.spawn(SpriteBundle {
-            sprite: Sprite {
-                color: Color::rgb(0.75, 0.25, 0.25),
-                custom_size: Some(Vec2::new(5., 5.)),
-                ..default()
-            },
-            transform: Transform::from_translation(pos),
-            ..default()
-        });
-    }
-}
-
 pub fn print_position_system(query: Query<&Transform>) {
     for transform in &query {
         println!("position: {:?}", transform.translation);


### PR DESCRIPTION
Adds a simple mothership spawning implementation inside the new function spawn_mothership(). Adds this system and the move_mothership system (slightly modified) to the plugin to be executed. 
Also removes the old spawn_text system from the plugin